### PR TITLE
add option to register callbacks for torque estimates messages

### DIFF
--- a/src/ODriveCAN.cpp
+++ b/src/ODriveCAN.cpp
@@ -159,7 +159,7 @@ void ODriveCAN::onReceive(uint32_t id, uint8_t length, const uint8_t* data) {
             Get_Torques_msg_t estimates;
             estimates.decode_buf(data);
             if (torques_callback_)
-                torques_callback_(estimates, feedback_user_data_);
+                torques_callback_(estimates, torques_user_data_);
             break;
         }
         case Heartbeat_msg_t::cmd_id: {

--- a/src/ODriveCAN.cpp
+++ b/src/ODriveCAN.cpp
@@ -155,6 +155,13 @@ void ODriveCAN::onReceive(uint32_t id, uint8_t length, const uint8_t* data) {
                 feedback_callback_(estimates, feedback_user_data_);
             break;
         }
+        case Get_Torques_msg_t::cmd_id: {
+            Get_Torques_msg_t estimates;
+            estimates.decode_buf(data);
+            if (torques_callback_)
+                torques_callback_(estimates, feedback_user_data_);
+            break;
+        }
         case Heartbeat_msg_t::cmd_id: {
             Heartbeat_msg_t status;
             status.decode_buf(data);

--- a/src/ODriveCAN.h
+++ b/src/ODriveCAN.h
@@ -213,6 +213,14 @@ public:
         axis_state_callback_ = callback; 
         axis_state_user_data_ = user_data;
     }
+    
+    /**
+     * @brief Registers a callback for ODrive torques feedback processing.
+     */
+    void onTorques(void (*callback)(Get_Torques_msg_t& feedback, void* user_data), void* user_data = nullptr) {
+        torques_callback_ = callback; 
+        feedback_user_data_ = user_data;
+    }
 
     /**
      * @brief Processes received CAN messages for the ODrive.
@@ -325,4 +333,5 @@ private:
     
     void (*axis_state_callback_)(Heartbeat_msg_t& feedback, void* user_data) = nullptr;
     void (*feedback_callback_)(Get_Encoder_Estimates_msg_t& feedback, void* user_data) = nullptr;
+    void (*torques_callback_)(Get_Torques_msg_t& feedback, void* user_data) = nullptr;
 };

--- a/src/ODriveCAN.h
+++ b/src/ODriveCAN.h
@@ -219,7 +219,7 @@ public:
      */
     void onTorques(void (*callback)(Get_Torques_msg_t& feedback, void* user_data), void* user_data = nullptr) {
         torques_callback_ = callback; 
-        feedback_user_data_ = user_data;
+        torques_user_data_ = user_data;
     }
 
     /**
@@ -330,6 +330,7 @@ private:
 
     void* axis_state_user_data_;
     void* feedback_user_data_;
+    void* torques_user_data_;
     
     void (*axis_state_callback_)(Heartbeat_msg_t& feedback, void* user_data) = nullptr;
     void (*feedback_callback_)(Get_Encoder_Estimates_msg_t& feedback, void* user_data) = nullptr;


### PR DESCRIPTION
Added option to register a callback for an incoming message of type _Get_Torques_msg_t_ . This enables registering a callback to process incoming torque messages. I do not have the hardware to test this right now, but I have tested it previously and got good results.