### PR TITLE
Simple addition to controll multi-axis odrives such as 3.6

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2017-2023 ODrive Robotics Inc.
+Copyright (c) 2025 Mathew3000
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/library.properties
+++ b/library.properties
@@ -1,6 +1,6 @@
 # https://arduino.github.io/arduino-cli/0.33/library-specification/
 name=ODriveArduino
-version=0.10.3
+version=0.10.4
 author=ODrive Robotics Inc. <info@odriverobotics.com>
 maintainer=ODrive Robotics Inc. <info@odriverobotics.com>
 sentence=Library to control ODrive motor controllers

--- a/src/ODriveUART.cpp
+++ b/src/ODriveUART.cpp
@@ -5,8 +5,6 @@
 #include "Arduino.h"
 #include "ODriveUART.h"
 
-static int kMotorNumber = 0;
-
 // Print with stream operator
 template<class T> inline Print& operator <<(Print &obj,     T arg) { obj.print(arg);    return obj; }
 template<>        inline Print& operator <<(Print &obj, float arg) { obj.print(arg, 4); return obj; }
@@ -15,17 +13,17 @@ ODriveUART::ODriveUART(Stream& serial)
     : serial_(serial) {}
 
 void ODriveUART::clearErrors() {
-    serial_ << "sc\n";
+    serial_ << F("sc\n");
 }
 
 void ODriveUART::selectAxis(int axis){
     if(axis >= 0 && axis < 2){
-        kMotorNumber = axis;
+        selected_axis = axis;
     }
 }
 
 int ODriveUART::getAxis(){
-    return kMotorNumber;
+    return selected_axis;
 }
 
 void ODriveUART::setPosition(float position) {
@@ -37,7 +35,7 @@ void ODriveUART::setPosition(float position, float velocity_feedforward) {
 }
 
 void ODriveUART::setPosition(float position, float velocity_feedforward, float torque_feedforward) {
-    serial_ << "p " << kMotorNumber  << " " << position << " " << velocity_feedforward << " " << torque_feedforward << "\n";
+    serial_ << F("p ") << selected_axis  << F(" ") << position << F(" ") << velocity_feedforward << F(" ") << torque_feedforward << F("\n");
 }
 
 void ODriveUART::setVelocity(float velocity) {
@@ -45,15 +43,15 @@ void ODriveUART::setVelocity(float velocity) {
 }
 
 void ODriveUART::setVelocity(float velocity, float torque_feedforward) {
-    serial_ << "v " << kMotorNumber  << " " << velocity << " " << torque_feedforward << "\n";
+    serial_ << F("v ") << selected_axis  << F(" ") << velocity << F(" ") << torque_feedforward << F("\n");
 }
 
 void ODriveUART::setTorque(float torque) {
-    serial_ << "c " << kMotorNumber << " " << torque << "\n";
+    serial_ << F("c ") << selected_axis << F(" ") << torque << F("\n");
 }
 
 void ODriveUART::trapezoidalMove(float position) {
-    serial_ << "t " << kMotorNumber << " " << position << "\n";
+    serial_ << F("t ") << selected_axis << F(" ") << position << F("\n");
 }
 
 ODriveFeedback ODriveUART::getFeedback() {
@@ -62,7 +60,7 @@ ODriveFeedback ODriveUART::getFeedback() {
         serial_.read();
     }
 
-    serial_ << "f " << kMotorNumber << "\n";
+    serial_ << F("f ") << selected_axis << F("\n");
 
     String response = readLine();
 
@@ -78,22 +76,22 @@ ODriveFeedback ODriveUART::getFeedback() {
 }
 
 String ODriveUART::getParameterAsString(const String& path) {
-    serial_ << "r " << path << "\n";
+    serial_ << F("r ") << path << F("\n");
     return readLine();
 }
 
 void ODriveUART::setParameter(const String& path, const String& value) {
-    serial_ << "w " << path << " " << value << "\n";
+    serial_ << F("w ") << path << F(" ") << value << F("\n");
 }
 
 void ODriveUART::setState(ODriveAxisState requested_state) {
-    if(kMotorNumber == 0) setParameter("axis0.requested_state", String((long)requested_state));
-    if(kMotorNumber == 1) setParameter("axis1.requested_state", String((long)requested_state));
+    String parameter = "axis" + String(selected_axis) + ".requested_state";
+    setParameter(parameter, String((long)requested_state));
 }
 
 ODriveAxisState ODriveUART::getState() {
-    if(kMotorNumber == 0) return (ODriveAxisState)getParameterAsInt("axis0.current_state");
-    if(kMotorNumber == 1) return (ODriveAxisState)getParameterAsInt("axis1.current_state");
+    String parameter = "axis" + String(selected_axis) + ".current_state";
+    return (ODriveAxisState)getParameterAsInt(parameter);
 }
 
 String ODriveUART::readLine(unsigned long timeout_ms) {

--- a/src/ODriveUART.cpp
+++ b/src/ODriveUART.cpp
@@ -19,7 +19,7 @@ void ODriveUART::clearErrors() {
 }
 
 void ODriveUART::selectAxis(int axis){
-    if(axis > 0 && axis < 2){
+    if(axis >= 0 && axis < 2){
         kMotorNumber = axis;
     }
 }

--- a/src/ODriveUART.h
+++ b/src/ODriveUART.h
@@ -18,7 +18,14 @@ public:
      */
     ODriveUART(Stream& serial);
 
+    /**
+     * @brief (Only ODrive 3.6) Select which axis to controll
+     */
     void selectAxis(int axis);
+    
+    /**
+     * @brief (Only ODrive 3.6) Check which axis is selected
+     */
     int getAxis();
 
     /**
@@ -104,6 +111,8 @@ public:
     ODriveAxisState getState();
 
 private:
+    int selected_axis = 0;
+
     String readLine(unsigned long timeout_ms = 10);
 
     Stream& serial_;

--- a/src/ODriveUART.h
+++ b/src/ODriveUART.h
@@ -18,6 +18,9 @@ public:
      */
     ODriveUART(Stream& serial);
 
+    void selectAxis(int axis);
+    int getAxis();
+
     /**
      * @brief Clears the error status of the ODrive and restarts the brake
      * resistor if it was disabled due to an error.


### PR DESCRIPTION
Hi, I am currently using the UART implementation of the library with an ODrive 3.6 and needed the possibility to change the controlled axis. 

To change as little as possible I added a command to set and get the `kMotorNumber` variable.

Set and Get state also now check this variable.

This can for sure be done in a more elegant way but I needed a quick solution.