### PR TITLE
Modified library for ESP32 native TWAI driver

### DIFF
--- a/examples/SineWaveCAN/SineWaveCAN.ino
+++ b/examples/SineWaveCAN/SineWaveCAN.ino
@@ -17,7 +17,7 @@
   // #define IS_TEENSY_BUILTIN // Teensy boards with built-in CAN interface (e.g. Teensy 4.1). See below to select which interface to use.
   // #define IS_ARDUINO_BUILTIN // Arduino boards with built-in CAN interface (e.g. Arduino Uno R4 Minima)
   // #define IS_MCP2515 // Any board with external MCP2515 based extension module. See below to configure the module.
-  #define IS_ESP32_TWAI // Any board with external MCP2515 based extension module. See below to configure the module.
+  // #define IS_ESP32_TWAI // ESP32 boards using a external transceiver such as sn65hvd230. Uses Espressif's native TWAI driver. Connect and TX_PIN from ESP32 to D on transceiver and RX_PIN from ESP32 to R on transceiver. 
 
 
 /* Board-specific includes ---------------------------------------------------*/

--- a/examples/SineWaveCAN/SineWaveCAN.ino
+++ b/examples/SineWaveCAN/SineWaveCAN.ino
@@ -8,7 +8,7 @@
   #define CAN_BAUDRATE 250000
 
   // ODrive node_id for odrv0
-  #define ODRV0_NODE_ID 31
+  #define ODRV0_NODE_ID 0
 
 
   // Uncomment below the line that corresponds to your hardware.

--- a/examples/SineWaveCAN/SineWaveCAN.ino
+++ b/examples/SineWaveCAN/SineWaveCAN.ino
@@ -59,17 +59,15 @@
   #ifdef IS_ESP32_TWAI
   // See https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/twai.html
   // https://github.com/espressif/arduino-esp32/tree/master/libraries/ESP32/examples/TWAI
-
+    // Pins used to connect to CAN bus transceiver:
     #define RX_PIN 35
     #define TX_PIN 36    
     #define TRANSMIT_RATE_MS 50
     #define POLLING_RATE_MS 50
   #include "driver/twai.h"
-  //probably not the best place to put this, but it is needed to be defined before calling ODriveESP32TWAI.hpp *******************move to ODriveESP32.hpp?
-    // Interval:
+
 
   #include "ODriveESP32TWAI.hpp"
-  //****vérifier si requis pour ESP32****// struct ODriveStatus; // hack to prevent teensy compile error
   #endif // IS_ESP32_TWAI
 
 /* Board-specific settings ---------------------------------------------------*/
@@ -133,18 +131,12 @@
   /* ESP32 board using native TWAI driver */
     #ifdef IS_ESP32_TWAI
 
-
-
-      //TWAIClass& can_intf = CAN; //**** not sure if i can actually comment this out. //
       TWAIClass can_intf;
 
-      // Pins used to connect to CAN bus transceiver:
-
-
       bool setupCan() {
-      if (!can_intf.begin(CAN_BAUDRATE)) {
-        return false;
-      }
+        if (!can_intf.begin(CAN_BAUDRATE)) {
+          return false;
+        }
         return true;
       }
 
@@ -205,7 +197,7 @@ void setup() {
   Serial.begin(115200);
   long current_millis = 0;
   while(!Serial){ 
-    if (millis() > current_millis + 3000){ //check for connection for 3 seconds
+    if ((millis() - current_millis)  > 3000){ //check for connection for 3 seconds
       break; //Break when connection found
     }
   }

--- a/examples/SineWaveCAN/SineWaveCAN.ino
+++ b/examples/SineWaveCAN/SineWaveCAN.ino
@@ -227,7 +227,7 @@ void setup() {
   Serial.println("Waiting for ODrive...");
   while (!odrv0_user_data.received_heartbeat) {
     pumpEvents(can_intf);
-    delay(50);
+    delay(100);
   }
 
   Serial.println("found ODrive");
@@ -251,7 +251,7 @@ void setup() {
     odrv0.clearErrors();
     delay(1);
     
-    odrv0.setState(ODriveAxisState::AXIS_STATE_CLOSED_LOOP_CONTROL); //test commande manuelle
+    odrv0.setState(ODriveAxisState::AXIS_STATE_CLOSED_LOOP_CONTROL);
 
     // Pump events for 150ms. This delay is needed for two reasons;
     // 1. If there is an error condition, such as missing DC power, the ODrive might
@@ -272,7 +272,11 @@ void setup() {
 
 void loop() {
   pumpEvents(can_intf); // This is required on some platforms to handle incoming feedback CAN messages
-
+                        // Note that on MCP2515-based platforms, this will delay for a fixed 10ms.
+                        //
+                        // This has been found to reduce the number of dropped messages, however it can be removed
+                        // for applications requiring loop times over 100Hz.
+                        
   float SINE_PERIOD = 2.0f; // Period of the position command sine wave in seconds
 
   float t = 0.001 * millis();

--- a/src/ODriveESP32TWAI.hpp
+++ b/src/ODriveESP32TWAI.hpp
@@ -15,7 +15,7 @@ struct CanMsg {
 void onCanMessage(const CanMsg& msg);
 
 
-static bool sendMsg(TWAIClass& can_intf, uint32_t id, uint8_t length, const uint8_t* data) {
+static inline bool sendMsg(TWAIClass& can_intf, uint32_t id, uint8_t length, const uint8_t* data) {
     // Send CAN message
     can_intf.prepareMessage(id, length, !data);
     if (data) {
@@ -26,11 +26,11 @@ static bool sendMsg(TWAIClass& can_intf, uint32_t id, uint8_t length, const uint
     return can_intf.endPacket();
 }
 
-static void onReceive(const CanMsg& msg, ODriveCAN& odrive) {
+static inline void onReceive(const CanMsg& msg, ODriveCAN& odrive) {
     odrive.onReceive(msg.id, msg.len, msg.buffer);
 }
 
-static void pumpEvents(TWAIClass& intf) {
+static inline void pumpEvents(TWAIClass& intf) {
     CanMsg msg;
     int length = intf.parsePacket(); // Check if a packet is available
 

--- a/src/ODriveESP32TWAI.hpp
+++ b/src/ODriveESP32TWAI.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "TWAI_CAN_Class.h" // Include your custom TWAIClass header
+#include "ODriveCAN.h"
+
+// This is a convenience struct because the TWAIClass doesn't have a
+// native message type.
+struct CanMsg {
+    uint32_t id;
+    uint8_t len;
+    uint8_t buffer[8];
+};
+
+// Must be defined by the application if you want to use defaultCanReceiveCallback().
+void onCanMessage(const CanMsg& msg);
+
+
+static bool sendMsg(TWAIClass& can_intf, uint32_t id, uint8_t length, const uint8_t* data) {
+    // Send CAN message
+    can_intf.prepareMessage(id, length, !data);
+    if (data) {
+        for (int i = 0; i < length; ++i) {
+            can_intf.write(data[i], i);
+        }
+    }
+    return can_intf.endPacket();
+}
+
+static void onReceive(const CanMsg& msg, ODriveCAN& odrive) {
+    odrive.onReceive(msg.id, msg.len, msg.buffer);
+}
+
+static void pumpEvents(TWAIClass& intf) {
+    CanMsg msg;
+    int length = intf.parsePacket(); // Check if a packet is available
+
+    if (length > 0) {
+        msg.id = intf.packetId(); // Retrieve the ID of the received message
+        // Debug print to check if ID is read correctly
+        //Serial.print("Received Raw Frame ID: 0x"); // DEBUG PRINT uncomment to print all messages to serial console **********************************
+        //Serial.println(msg.id, HEX); // DEBUG PRINT uncomment to print all messages to serial console **********************************
+        msg.len = length;
+        intf.readBytes(msg.buffer, length); // Retrieve the data from the message
+        onCanMessage(msg); // Call the user-defined callback
+    }
+}
+
+CREATE_CAN_INTF_WRAPPER(TWAIClass)

--- a/src/TWAI_CAN_Class.h
+++ b/src/TWAI_CAN_Class.h
@@ -14,6 +14,7 @@ public:
   bool begin(long baudRate) {
     if (is_initialized) return false;  // Already initialized
     // Configure TWAI (CAN) settings
+    twai_general_config_t g_config = TWAI_GENERAL_CONFIG_DEFAULT((gpio_num_t)TX_PIN, (gpio_num_t)RX_PIN, TWAI_MODE_NORMAL);
     // Select baud rate using switch-case. Ensure it matches ODrive configuration
     twai_timing_config_t t_config;
     switch (baudRate) {

--- a/src/TWAI_CAN_Class.h
+++ b/src/TWAI_CAN_Class.h
@@ -1,0 +1,134 @@
+#ifndef TWAI_CAN_CLASS_H
+#define TWAI_CAN_CLASS_H
+
+//#include "driver/twai.h"
+
+class TWAIClass {
+public:
+    TWAIClass() : is_initialized(false) {}
+    ~TWAIClass() {
+        if (is_initialized) {
+            end();
+        }
+    }
+	
+bool begin(long baudRate) {
+    if (is_initialized) return false;  // Already initialized
+    
+    // Configure TWAI (CAN) settings
+    twai_general_config_t g_config = TWAI_GENERAL_CONFIG_DEFAULT((gpio_num_t)TX_PIN, (gpio_num_t)RX_PIN, TWAI_MODE_NORMAL);
+    //TODO ADD SWITCH CASE FOR DIFFERENT BAUDRATE****************************************************************************************************************
+    twai_timing_config_t t_config = TWAI_TIMING_CONFIG_250KBITS();  // Ensure it matches ODrive
+    twai_filter_config_t f_config = TWAI_FILTER_CONFIG_ACCEPT_ALL();
+
+    // Install the TWAI driver
+    if (twai_driver_install(&g_config, &t_config, &f_config) != ESP_OK) {
+        Serial.println("❌ TWAI Driver install failed!");
+        return false;
+    }
+
+    // Start TWAI driver
+    if (twai_start() != ESP_OK) {
+        Serial.println("❌ TWAI Driver start failed!");
+        twai_driver_uninstall();
+        return false;
+    }
+
+    // Configure TWAI Alerts (Monitor TX and Bus Errors)
+    uint32_t alerts_to_enable = TWAI_ALERT_TX_IDLE | TWAI_ALERT_TX_SUCCESS | 
+                                TWAI_ALERT_TX_FAILED | TWAI_ALERT_ERR_PASS | TWAI_ALERT_BUS_ERROR;
+    if (twai_reconfigure_alerts(alerts_to_enable, NULL) != ESP_OK) {
+        Serial.println("❌ Failed to configure CAN Alerts!");
+        return false;
+    }
+
+    Serial.println("✅ TWAI CAN Bus Started Successfully!");
+    is_initialized = true;
+    return true;
+}
+
+    // End CAN communication
+    void end() {
+        if (is_initialized) {
+            twai_stop();
+            twai_driver_uninstall();
+            is_initialized = false;
+        }
+    }
+
+    // Send a CAN message
+    int endPacket() {
+        if (!is_initialized || !message_ready) {
+            return 0; // Not initialized or no message ready
+        }
+
+        if (twai_transmit(&tx_message, pdMS_TO_TICKS(100)) == ESP_OK) {
+            message_ready = false;
+            return 1; // Successfully sent message
+        }
+
+        return 0; // Failed to send message
+    }
+
+    // Prepare a CAN messagewrite
+    void prepareMessage(uint32_t id, uint8_t length, bool rtr = false) {
+        tx_message.identifier = id;
+        tx_message.data_length_code = length;
+        //tx_message.rtr = rtr ? TWAI_RTR : TWAI_NO_RTR; //TODO this line doesnt compile. verify if required for odrive*******************************************
+
+		tx_message.rtr = 0;
+        tx_message.extd = (id > 0x7FF); // Extended frame if ID > 11 bits
+        message_ready = true;
+    }
+
+    // Write data to the CAN message
+    void write(uint8_t byte, int index) {
+        if (index >= 0 && index < 8) {
+            tx_message.data[index] = byte;
+        }
+    }
+
+    // Parse incoming CAN packet
+    int parsePacket() {
+        if (!is_initialized) {
+            return 0; // Not initialized
+        }
+
+        if (twai_receive(&rx_message, pdMS_TO_TICKS(10)) == ESP_OK) {
+            return rx_message.data_length_code; // Number of bytes received
+        }
+
+        return 0; // No packet received
+    }
+
+    // Access packet ID
+    uint32_t packetId() {
+        return rx_message.identifier;
+    }
+
+    // Access received data
+    void readBytes(uint8_t* buffer, uint8_t length) {
+      if (length > 8) length = 8; // Maximum data length
+      for (uint8_t i = 0; i < length; ++i) {
+          buffer[i] = rx_message.data[i];
+          //Serial.printf(" %d = %02x,", i, rx_message.data[i]); // DEBUG PRINT uncomment to print all messages to serial console **********************************
+      }
+      //Serial.println(""); //uncomment to print all messages to serial console **********************************
+    }
+
+    // Callback for received messages
+    void onReceive(void (*callback)(int)) {
+        receive_callback = callback;
+    }
+
+private:
+    bool is_initialized;
+    bool message_ready = false;
+    twai_message_t tx_message;
+    twai_message_t rx_message;
+    void (*receive_callback)(int) = nullptr;
+};
+
+extern TWAIClass CAN;
+
+#endif // TWAI_CAN_CLASS_H

--- a/src/TWAI_CAN_Class.h
+++ b/src/TWAI_CAN_Class.h
@@ -1,8 +1,6 @@
 #ifndef TWAI_CAN_CLASS_H
 #define TWAI_CAN_CLASS_H
 
-//#include "driver/twai.h"
-
 class TWAIClass {
 public:
     TWAIClass() : is_initialized(false) {}
@@ -16,20 +14,49 @@ bool begin(long baudRate) {
     if (is_initialized) return false;  // Already initialized
     
     // Configure TWAI (CAN) settings
-    twai_general_config_t g_config = TWAI_GENERAL_CONFIG_DEFAULT((gpio_num_t)TX_PIN, (gpio_num_t)RX_PIN, TWAI_MODE_NORMAL);
-    //TODO ADD SWITCH CASE FOR DIFFERENT BAUDRATE****************************************************************************************************************
-    twai_timing_config_t t_config = TWAI_TIMING_CONFIG_250KBITS();  // Ensure it matches ODrive
+    // Select baud rate using switch-case. Ensure it matches ODrive configuration
+    twai_timing_config_t t_config;
+    switch (baudRate) {
+        case 1000000:
+            t_config = TWAI_TIMING_CONFIG_1MBITS();
+            break;
+        case 800000:
+            t_config = TWAI_TIMING_CONFIG_800KBITS();
+            break;
+        case 500000:
+            t_config = TWAI_TIMING_CONFIG_500KBITS();
+            break;
+        case 250000:
+            t_config = TWAI_TIMING_CONFIG_250KBITS();
+            break;
+        case 125000:
+            t_config = TWAI_TIMING_CONFIG_125KBITS();
+            break;
+        case 100000:
+            t_config = TWAI_TIMING_CONFIG_100KBITS();
+            break;
+        case 50000:
+            t_config = TWAI_TIMING_CONFIG_50KBITS();
+            break;
+        case 25000:
+            t_config = TWAI_TIMING_CONFIG_25KBITS();
+            break;
+        default:
+            Serial.println("Unsupported baud rate! Defaulting to 250Kbps.");
+            t_config = TWAI_TIMING_CONFIG_250KBITS();
+            break;
+    }    
     twai_filter_config_t f_config = TWAI_FILTER_CONFIG_ACCEPT_ALL();
 
     // Install the TWAI driver
     if (twai_driver_install(&g_config, &t_config, &f_config) != ESP_OK) {
-        Serial.println("❌ TWAI Driver install failed!");
+        Serial.println("TWAI Driver install failed!");
         return false;
     }
 
     // Start TWAI driver
     if (twai_start() != ESP_OK) {
-        Serial.println("❌ TWAI Driver start failed!");
+        Serial.println("TWAI Driver start failed!");
         twai_driver_uninstall();
         return false;
     }
@@ -38,11 +65,11 @@ bool begin(long baudRate) {
     uint32_t alerts_to_enable = TWAI_ALERT_TX_IDLE | TWAI_ALERT_TX_SUCCESS | 
                                 TWAI_ALERT_TX_FAILED | TWAI_ALERT_ERR_PASS | TWAI_ALERT_BUS_ERROR;
     if (twai_reconfigure_alerts(alerts_to_enable, NULL) != ESP_OK) {
-        Serial.println("❌ Failed to configure CAN Alerts!");
+        Serial.println("Failed to configure CAN Alerts!");
         return false;
     }
 
-    Serial.println("✅ TWAI CAN Bus Started Successfully!");
+    Serial.println("TWAI CAN Bus Started Successfully!");
     is_initialized = true;
     return true;
 }

--- a/src/TWAI_CAN_Class.h
+++ b/src/TWAI_CAN_Class.h
@@ -3,159 +3,158 @@
 
 class TWAIClass {
 public:
-    TWAIClass() : is_initialized(false) {}
-    ~TWAIClass() {
-        if (is_initialized) {
-            end();
-        }
+ TWAIClass()
+    : is_initialized(false) {}
+  ~TWAIClass() {
+    if (is_initialized) {
+      end();
     }
-	
-bool begin(long baudRate) {
+  }
+
+  bool begin(long baudRate) {
     if (is_initialized) return false;  // Already initialized
-    
     // Configure TWAI (CAN) settings
     // Select baud rate using switch-case. Ensure it matches ODrive configuration
     twai_timing_config_t t_config;
     switch (baudRate) {
-        case 1000000:
-            t_config = TWAI_TIMING_CONFIG_1MBITS();
-            break;
-        case 800000:
-            t_config = TWAI_TIMING_CONFIG_800KBITS();
-            break;
-        case 500000:
-            t_config = TWAI_TIMING_CONFIG_500KBITS();
-            break;
-        case 250000:
-            t_config = TWAI_TIMING_CONFIG_250KBITS();
-            break;
-        case 125000:
-            t_config = TWAI_TIMING_CONFIG_125KBITS();
-            break;
-        case 100000:
-            t_config = TWAI_TIMING_CONFIG_100KBITS();
-            break;
-        case 50000:
-            t_config = TWAI_TIMING_CONFIG_50KBITS();
-            break;
-        case 25000:
-            t_config = TWAI_TIMING_CONFIG_25KBITS();
-            break;
-        default:
-            Serial.println("Unsupported baud rate! Defaulting to 250Kbps.");
-            t_config = TWAI_TIMING_CONFIG_250KBITS();
-            break;
-    }    
+      case 1000000:
+        t_config = TWAI_TIMING_CONFIG_1MBITS();
+        break;
+      case 800000:
+        t_config = TWAI_TIMING_CONFIG_800KBITS();
+        break;
+      case 500000:
+        t_config = TWAI_TIMING_CONFIG_500KBITS();
+        break;
+      case 250000:
+        t_config = TWAI_TIMING_CONFIG_250KBITS();
+        break;
+      case 125000:
+        t_config = TWAI_TIMING_CONFIG_125KBITS();
+        break;
+      case 100000:
+        t_config = TWAI_TIMING_CONFIG_100KBITS();
+        break;
+      case 50000:
+        t_config = TWAI_TIMING_CONFIG_50KBITS();
+        break;
+      case 25000:
+        t_config = TWAI_TIMING_CONFIG_25KBITS();
+        break;
+      default:
+        Serial.println("Unsupported baud rate! Defaulting to 250Kbps.");
+        t_config = TWAI_TIMING_CONFIG_250KBITS();
+        break;
+    }
     twai_filter_config_t f_config = TWAI_FILTER_CONFIG_ACCEPT_ALL();
 
     // Install the TWAI driver
     if (twai_driver_install(&g_config, &t_config, &f_config) != ESP_OK) {
-        Serial.println("TWAI Driver install failed!");
-        return false;
+      Serial.println("TWAI Driver install failed!");
+      return false;
     }
 
     // Start TWAI driver
     if (twai_start() != ESP_OK) {
-        Serial.println("TWAI Driver start failed!");
-        twai_driver_uninstall();
-        return false;
+      Serial.println("TWAI Driver start failed!");
+      twai_driver_uninstall();
+      return false;
     }
 
     // Configure TWAI Alerts (Monitor TX and Bus Errors)
-    uint32_t alerts_to_enable = TWAI_ALERT_TX_IDLE | TWAI_ALERT_TX_SUCCESS | 
-                                TWAI_ALERT_TX_FAILED | TWAI_ALERT_ERR_PASS | TWAI_ALERT_BUS_ERROR;
+    uint32_t alerts_to_enable = TWAI_ALERT_TX_IDLE | TWAI_ALERT_TX_SUCCESS | TWAI_ALERT_TX_FAILED | TWAI_ALERT_ERR_PASS | TWAI_ALERT_BUS_ERROR;
     if (twai_reconfigure_alerts(alerts_to_enable, NULL) != ESP_OK) {
-        Serial.println("Failed to configure CAN Alerts!");
-        return false;
+      Serial.println("Failed to configure CAN Alerts!");
+      return false;
     }
 
     Serial.println("TWAI CAN Bus Started Successfully!");
     is_initialized = true;
     return true;
-}
+  }
 
-    // End CAN communication
-    void end() {
-        if (is_initialized) {
-            twai_stop();
-            twai_driver_uninstall();
-            is_initialized = false;
-        }
+  // End CAN communication
+  void end() {
+    if (is_initialized) {
+      twai_stop();
+      twai_driver_uninstall();
+      is_initialized = false;
+    }
+  }
+
+  // Send a CAN message
+  int endPacket() {
+    if (!is_initialized || !message_ready) {
+      return 0;  // Not initialized or no message ready
     }
 
-    // Send a CAN message
-    int endPacket() {
-        if (!is_initialized || !message_ready) {
-            return 0; // Not initialized or no message ready
-        }
-
-        if (twai_transmit(&tx_message, pdMS_TO_TICKS(100)) == ESP_OK) {
-            message_ready = false;
-            return 1; // Successfully sent message
-        }
-
-        return 0; // Failed to send message
+    if (twai_transmit(&tx_message, pdMS_TO_TICKS(100)) == ESP_OK) {
+      message_ready = false;
+      return 1;  // Successfully sent message
     }
 
-    // Prepare a CAN messagewrite
-    void prepareMessage(uint32_t id, uint8_t length, bool rtr = false) {
-        tx_message.identifier = id;
-        tx_message.data_length_code = length;
-        //tx_message.rtr = rtr ? TWAI_RTR : TWAI_NO_RTR; //TODO this line doesnt compile. verify if required for odrive*******************************************
+    return 0;  // Failed to send message
+  }
 
-		tx_message.rtr = 0;
-        tx_message.extd = (id > 0x7FF); // Extended frame if ID > 11 bits
-        message_ready = true;
+  // Prepare a CAN messagewrite
+  void prepareMessage(uint32_t id, uint8_t length, bool rtr = false) {
+    tx_message.identifier = id;
+    tx_message.data_length_code = length;
+    //tx_message.rtr = rtr ? TWAI_RTR : TWAI_NO_RTR; //TODO this line doesnt compile. verify if required for odrive*******************************************
+
+    tx_message.rtr = 0;
+    tx_message.extd = (id > 0x7FF);  // Extended frame if ID > 11 bits
+    message_ready = true;
+  }
+
+  // Write data to the CAN message
+  void write(uint8_t byte, int index) {
+    if (index >= 0 && index < 8) {
+      tx_message.data[index] = byte;
+    }
+  }
+
+  // Parse incoming CAN packet
+  int parsePacket() {
+    if (!is_initialized) {
+      return 0;  // Not initialized
     }
 
-    // Write data to the CAN message
-    void write(uint8_t byte, int index) {
-        if (index >= 0 && index < 8) {
-            tx_message.data[index] = byte;
-        }
+    if (twai_receive(&rx_message, pdMS_TO_TICKS(10)) == ESP_OK) {
+      return rx_message.data_length_code;  // Number of bytes received
     }
 
-    // Parse incoming CAN packet
-    int parsePacket() {
-        if (!is_initialized) {
-            return 0; // Not initialized
-        }
+    return 0;  // No packet received
+  }
 
-        if (twai_receive(&rx_message, pdMS_TO_TICKS(10)) == ESP_OK) {
-            return rx_message.data_length_code; // Number of bytes received
-        }
+  // Access packet ID
+  uint32_t packetId() {
+    return rx_message.identifier;
+  }
 
-        return 0; // No packet received
+  // Access received data
+  void readBytes(uint8_t* buffer, uint8_t length) {
+    if (length > 8) length = 8;  // Maximum data length
+    for (uint8_t i = 0; i < length; ++i) {
+      buffer[i] = rx_message.data[i];
+      //Serial.printf(" %d = %02x,", i, rx_message.data[i]); // DEBUG PRINT uncomment to print all messages to serial console **********************************
     }
+    //Serial.println(""); //uncomment to print all messages to serial console **********************************
+  }
 
-    // Access packet ID
-    uint32_t packetId() {
-        return rx_message.identifier;
-    }
-
-    // Access received data
-    void readBytes(uint8_t* buffer, uint8_t length) {
-      if (length > 8) length = 8; // Maximum data length
-      for (uint8_t i = 0; i < length; ++i) {
-          buffer[i] = rx_message.data[i];
-          //Serial.printf(" %d = %02x,", i, rx_message.data[i]); // DEBUG PRINT uncomment to print all messages to serial console **********************************
-      }
-      //Serial.println(""); //uncomment to print all messages to serial console **********************************
-    }
-
-    // Callback for received messages
-    void onReceive(void (*callback)(int)) {
-        receive_callback = callback;
-    }
+  // Callback for received messages
+  void onReceive(void (*callback)(int)) {
+    receive_callback = callback;
+  }
 
 private:
-    bool is_initialized;
-    bool message_ready = false;
-    twai_message_t tx_message;
-    twai_message_t rx_message;
-    void (*receive_callback)(int) = nullptr;
+  bool is_initialized;
+  bool message_ready = false;
+  twai_message_t tx_message;
+  twai_message_t rx_message;
+  void (*receive_callback)(int) = nullptr;
 };
 
 extern TWAIClass CAN;
 
-#endif // TWAI_CAN_CLASS_H
+#endif  // TWAI_CAN_CLASS_H


### PR DESCRIPTION
created two new files to go with the OdriveArduino library. TWAI_CAN_Class.h and ODriveESP32TWAI.hpp. They enable the use of the native TWAI drivers of the Arduino core for the ESP32. It enables the use of a simple transceiver like an SN65HVD230 instead of requiring an SPI interface. 
The main sketch is updated to add the corresponding board-specific include and setting sections. 
The indentation of the board specific settings was also modified to enable code folding in Arduino IDE 2. 
Changed the Serial Begin to wait for communication to open but allow execution after a certain amount of time