### PR TITLE
Check requested message before trying callbacks

### DIFF
--- a/src/ODriveCAN.h
+++ b/src/ODriveCAN.h
@@ -161,7 +161,7 @@ public:
     bool getVersion(Get_Version_msg_t& msg, uint16_t timeout_ms = 10);
 
     /**
-     * @brief Requests encoder feedback data.  May trigger onFeedback callback if it's registered
+     * @brief Requests encoder feedback data.
      * 
      * This function will block and wait for up to timeout_ms (default 10msec) for ODrive to reply
      */


### PR DESCRIPTION
Hi,

I encountered this while working on https://github.com/odriverobotics/ODriveArduino/issues/13.
Here is an example program to reproduce it: https://gist.github.com/BrechtSerckx/e682a30fb946292be58ab2be64ed49e3.
When no feedback handler is registered, calls to `getFeedback` fail. When a feedback handler is registered, calls still fail, but the callback is called.
`getFeedback` should not conflict with registered callbacks.

This patch first checks if a CAN message has been requested. Only if it wasn't, the callback handlers are checked.