### PR TITLE
Support for all cyclic messages

### DIFF
--- a/src/ODriveCAN.cpp
+++ b/src/ODriveCAN.cpp
@@ -178,6 +178,13 @@ void ODriveCAN::onReceive(uint32_t id, uint8_t length, const uint8_t* data) {
                 temperature_callback_(temperature, temperature_user_data_);
             break;
         }
+        case Get_Bus_Voltage_Current_msg_t::cmd_id: {
+            Get_Bus_Voltage_Current_msg_t bus_vi;
+            bus_vi.decode_buf(data);
+            if (busVI_callback_)
+                busVI_callback_(bus_vi, busVI_user_data_);
+            break;
+        }
         default: {
             if (requested_msg_id_ == REQUEST_PENDING)
                 return;

--- a/src/ODriveCAN.cpp
+++ b/src/ODriveCAN.cpp
@@ -171,6 +171,13 @@ void ODriveCAN::onReceive(uint32_t id, uint8_t length, const uint8_t* data) {
                 Serial.println(F("missing callback"));
             break;
         }
+        case Get_Temperature_msg_t::cmd_id: {
+            Get_Temperature_msg_t temperature;
+            temperature.decode_buf(data);
+            if (temperature_callback_)
+                temperature_callback_(temperature, temperature_user_data_);
+            break;
+        }
         default: {
             if (requested_msg_id_ == REQUEST_PENDING)
                 return;

--- a/src/ODriveCAN.cpp
+++ b/src/ODriveCAN.cpp
@@ -185,6 +185,13 @@ void ODriveCAN::onReceive(uint32_t id, uint8_t length, const uint8_t* data) {
                 busVI_callback_(bus_vi, busVI_user_data_);
             break;
         }
+        case Get_Iq_msg_t::cmd_id: {
+            Get_Iq_msg_t iq;
+            iq.decode_buf(data);
+            if (currents_callback_)
+                currents_callback_(iq, currents_user_data_);
+            break;
+        }
         default: {
             if (requested_msg_id_ == REQUEST_PENDING)
                 return;

--- a/src/ODriveCAN.cpp
+++ b/src/ODriveCAN.cpp
@@ -192,6 +192,13 @@ void ODriveCAN::onReceive(uint32_t id, uint8_t length, const uint8_t* data) {
                 currents_callback_(iq, currents_user_data_);
             break;
         }
+        case Get_Error_msg_t::cmd_id: {
+            Get_Error_msg_t error;
+            error.decode_buf(data);
+            if (error_callback_)
+                error_callback_(error, error_user_data_);
+            break;
+        }
         default: {
             if (requested_msg_id_ == REQUEST_PENDING)
                 return;

--- a/src/ODriveCAN.h
+++ b/src/ODriveCAN.h
@@ -248,6 +248,14 @@ public:
     }
 
     /**
+     * @brief Registers a callback for ODrive error messages.
+     */
+    void onError(void (*callback)(Get_Error_msg_t& msg, void* user_data), void* user_data = nullptr) {
+        error_callback_ = callback;
+        error_user_data_ = user_data;
+    }
+
+    /**
      * @brief Processes received CAN messages for the ODrive.
      */
     void onReceive(uint32_t id, uint8_t length, const uint8_t* data);
@@ -360,6 +368,7 @@ private:
     void* temperature_user_data_;
     void* busVI_user_data_;
     void* currents_user_data_;
+    void* error_user_data_;
     
     void (*axis_state_callback_)(Heartbeat_msg_t& feedback, void* user_data) = nullptr;
     void (*feedback_callback_)(Get_Encoder_Estimates_msg_t& feedback, void* user_data) = nullptr;
@@ -367,4 +376,5 @@ private:
     void (*temperature_callback_)(Get_Temperature_msg_t& feedback, void* user_data) = nullptr;
     void (*busVI_callback_)(Get_Bus_Voltage_Current_msg_t& feedback, void* user_data) = nullptr;
     void (*currents_callback_)(Get_Iq_msg_t& feedback, void* user_data) = nullptr;
+    void (*error_callback_)(Get_Error_msg_t& msg, void* user_data) = nullptr;
 };

--- a/src/ODriveCAN.h
+++ b/src/ODriveCAN.h
@@ -240,6 +240,14 @@ public:
     }
 
     /**
+     * @brief Registers a callback for ODrive currents feedback.
+     */
+    void onCurrents(void (*callback)(Get_Iq_msg_t& feedback, void* user_data), void* user_data = nullptr) {
+        currents_callback_ = callback;
+        currents_user_data_ = user_data;
+    }
+
+    /**
      * @brief Processes received CAN messages for the ODrive.
      */
     void onReceive(uint32_t id, uint8_t length, const uint8_t* data);
@@ -351,10 +359,12 @@ private:
     void* torques_user_data_;
     void* temperature_user_data_;
     void* busVI_user_data_;
+    void* currents_user_data_;
     
     void (*axis_state_callback_)(Heartbeat_msg_t& feedback, void* user_data) = nullptr;
     void (*feedback_callback_)(Get_Encoder_Estimates_msg_t& feedback, void* user_data) = nullptr;
     void (*torques_callback_)(Get_Torques_msg_t& feedback, void* user_data) = nullptr;
     void (*temperature_callback_)(Get_Temperature_msg_t& feedback, void* user_data) = nullptr;
     void (*busVI_callback_)(Get_Bus_Voltage_Current_msg_t& feedback, void* user_data) = nullptr;
+    void (*currents_callback_)(Get_Iq_msg_t& feedback, void* user_data) = nullptr;
 };

--- a/src/ODriveCAN.h
+++ b/src/ODriveCAN.h
@@ -223,6 +223,14 @@ public:
     }
 
     /**
+     * @brief Registers a callback for ODrive temperature feedback.
+     */
+    void onTemperature(void (*callback)(Get_Temperature_msg_t& feedback, void* user_data), void* user_data = nullptr) {
+        temperature_callback_ = callback;
+        temperature_user_data_ = user_data;
+    }
+
+    /**
      * @brief Processes received CAN messages for the ODrive.
      */
     void onReceive(uint32_t id, uint8_t length, const uint8_t* data);
@@ -332,8 +340,10 @@ private:
     void* axis_state_user_data_;
     void* feedback_user_data_;
     void* torques_user_data_;
+    void* temperature_user_data_;
     
     void (*axis_state_callback_)(Heartbeat_msg_t& feedback, void* user_data) = nullptr;
     void (*feedback_callback_)(Get_Encoder_Estimates_msg_t& feedback, void* user_data) = nullptr;
     void (*torques_callback_)(Get_Torques_msg_t& feedback, void* user_data) = nullptr;
+    void (*temperature_callback_)(Get_Temperature_msg_t& feedback, void* user_data) = nullptr;
 };

--- a/src/ODriveCAN.h
+++ b/src/ODriveCAN.h
@@ -171,6 +171,7 @@ public:
      * @brief Requests ODrive DC bus voltage and current
      * 
      * This function will block and wait for up to timeout_ms (default 10msec) for ODrive to reply
+     * May trigger onBusVI callback if it's registered.
      */
     bool getBusVI(Get_Bus_Voltage_Current_msg_t& msg, uint16_t timeout_ms = 10);
 
@@ -228,6 +229,14 @@ public:
     void onTemperature(void (*callback)(Get_Temperature_msg_t& feedback, void* user_data), void* user_data = nullptr) {
         temperature_callback_ = callback;
         temperature_user_data_ = user_data;
+    }
+
+    /**
+     * @brief Registers a callback for ODrive bus voltage/current feedback.
+     */
+    void onBusVI(void (*callback)(Get_Bus_Voltage_Current_msg_t& feedback, void* user_data), void* user_data = nullptr) {
+        busVI_callback_ = callback;
+        busVI_user_data_ = user_data;
     }
 
     /**
@@ -341,9 +350,11 @@ private:
     void* feedback_user_data_;
     void* torques_user_data_;
     void* temperature_user_data_;
+    void* busVI_user_data_;
     
     void (*axis_state_callback_)(Heartbeat_msg_t& feedback, void* user_data) = nullptr;
     void (*feedback_callback_)(Get_Encoder_Estimates_msg_t& feedback, void* user_data) = nullptr;
     void (*torques_callback_)(Get_Torques_msg_t& feedback, void* user_data) = nullptr;
     void (*temperature_callback_)(Get_Temperature_msg_t& feedback, void* user_data) = nullptr;
+    void (*busVI_callback_)(Get_Bus_Voltage_Current_msg_t& feedback, void* user_data) = nullptr;
 };


### PR DESCRIPTION
This is a fix for #13.
Example program: https://gist.github.com/BrechtSerckx/6d23b859b3192aa284aa145c497aafe5

This will probably break the example program in the library unless https://github.com/odriverobotics/ODriveArduino/pull/14 is merged in, as currently the callback for `GetBusVI` will intercept explicitly requested messages.