### PR TITLE
Add support for ESP32 boards using the native TWAI (CAN) driver.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [0.10.9]
+- Add support for ESP32 TWAI
+
 # [0.10.8]
 - Removed delay while waiting for heartbeat message, causing infinite/nondeterministic delays on some Teensy-based systems with multiple ODrives.
 

--- a/examples/SineWaveCAN/SineWaveCAN.ino
+++ b/examples/SineWaveCAN/SineWaveCAN.ino
@@ -208,7 +208,6 @@ bool setupCan() {
         return false;
     }
 
-    can_intf.initialized = true;
     return true;
 }
 

--- a/examples/SineWaveCAN/SineWaveCAN.ino
+++ b/examples/SineWaveCAN/SineWaveCAN.ino
@@ -172,8 +172,8 @@ bool setupCan() {
 #ifdef IS_ESP32_TWAI
 
 // Pins used to connect to CAN bus transceiver
-#define ESP32_TWAI_TX_PIN 5
-#define ESP32_TWAI_RX_PIN 4
+#define ESP32_TWAI_TX_PIN 26
+#define ESP32_TWAI_RX_PIN 25
 
 ESP32TWAIIntf can_intf;
 

--- a/library.properties
+++ b/library.properties
@@ -1,6 +1,6 @@
 # https://arduino.github.io/arduino-cli/0.33/library-specification/
 name=ODriveArduino
-version=0.10.8
+version=0.10.9
 author=ODrive Robotics Inc. <info@odriverobotics.com>
 maintainer=ODrive Robotics Inc. <info@odriverobotics.com>
 sentence=Library to control ODrive motor controllers

--- a/platformio.ini
+++ b/platformio.ini
@@ -47,3 +47,9 @@ build_flags =
   -DHAL_CAN_MODULE_ENABLED
 lib_deps =
     https://github.com/pazi88/STM32_CAN.git#1.2.0
+
+[env:esp32]
+platform = espressif32
+board = esp32dev
+framework = arduino
+build_flags = -DIS_ESP32_TWAI

--- a/src/ODriveESP32TWAI.hpp
+++ b/src/ODriveESP32TWAI.hpp
@@ -1,0 +1,66 @@
+// CAN glue layer for ESP32 platforms using the native TWAI driver.
+// See ODriveHardwareCAN.hpp for documentation.
+
+#pragma once
+
+#include "ODriveCAN.h"
+#include "driver/twai.h"
+
+// Simple struct to hold TWAI interface state. Unlike other platforms, ESP32's
+// TWAI driver uses global functions rather than a class instance.
+struct ESP32TWAIIntf {
+    bool initialized = false;
+};
+
+struct CanMsg {
+    uint32_t id;
+    uint8_t len;
+    uint8_t buffer[8];
+};
+
+// Must be defined by the application
+void onCanMessage(const CanMsg& msg);
+
+static bool sendMsg(ESP32TWAIIntf& intf, uint32_t id, uint8_t length, const uint8_t* data) {
+    if (!intf.initialized) {
+        return false;
+    }
+
+    twai_message_t tx_msg = {};
+    tx_msg.identifier = id;
+    tx_msg.data_length_code = length;
+    tx_msg.extd = (id > 0x7FF) ? 1 : 0;
+    tx_msg.rtr = (data == nullptr) ? 1 : 0;
+
+    if (data) {
+        for (int i = 0; i < length; ++i) {
+            tx_msg.data[i] = data[i];
+        }
+    }
+
+    return twai_transmit(&tx_msg, pdMS_TO_TICKS(100)) == ESP_OK;
+}
+
+static void onReceive(const CanMsg& msg, ODriveCAN& odrive) {
+    odrive.onReceive(msg.id, msg.len, msg.buffer);
+}
+
+static void pumpEvents(ESP32TWAIIntf& intf, int max_events = 100) {
+    if (!intf.initialized) {
+        return;
+    }
+
+    // max_events prevents an infinite loop if messages come at a high rate
+    twai_message_t rx_msg;
+    while (twai_receive(&rx_msg, 0) == ESP_OK && max_events--) {
+        CanMsg msg;
+        msg.id = rx_msg.identifier;
+        msg.len = rx_msg.data_length_code;
+        for (int i = 0; i < rx_msg.data_length_code && i < 8; ++i) {
+            msg.buffer[i] = rx_msg.data[i];
+        }
+        onCanMessage(msg);
+    }
+}
+
+CREATE_CAN_INTF_WRAPPER(ESP32TWAIIntf)


### PR DESCRIPTION
Changes:
- Add ODriveESP32TWAI.hpp interface
- Add IS_ESP32_TWAI option to SineWaveCAN example
- Add esp32 PlatformIO target

This PR supersedes #11 .

Not tested yet - will desk test ASAP. 